### PR TITLE
Implemented module scoped fixtures.

### DIFF
--- a/lib/ex_unit_fixtures.ex
+++ b/lib/ex_unit_fixtures.ex
@@ -24,7 +24,7 @@ defmodule ExUnitFixtures do
       iex(3)> Module.defines?(MyTests, :create_my_model)
       true
 
-  #### Fixtures with dependencies
+  ## Fixtures with dependencies
 
   Fixtures can also depend on other fixtures by naming a parameter after that
   fixture. For example, if you needed to setup a database instance before
@@ -57,7 +57,18 @@ defmodule ExUnitFixtures do
   `my_model` which depends on the database. ExUnitFixtures knows this, and takes
   care of setting up the database and passing it in to `my_model`.
 
-  #### Tearing down Fixtures
+  ## Fixture Scoping
+
+  Fixtures may optionally be provided with a scope:
+
+  - `:test` scoped fixtures will be created before a test and deleted afterwards.
+    This is the default scope for a fixture.
+  - `:module` scoped fixtures will be created at the start of a test module and
+    passed to every single test in the module.
+
+  For details on how to specify scopes, see `deffixture/3`.
+
+  ## Tearing down Fixtures
 
   If you need to do some teardown work for a fixture you can use the ExUnit
   `on_exit` function:
@@ -101,6 +112,18 @@ defmodule ExUnitFixtures do
       deffixture model(database) do
         %{model: true}
       end
+
+  #### Fixture Options
+
+  Fixtures can accept various options that control how they are defined:
+
+      deffixture database, scope: :module do
+        %{database: true}
+      end
+
+  These options are supported:
+
+  - `scope` controls the scope of fixtures. See Fixture Scoping for details.
   """
   defmacro deffixture({name, info, params}, opts \\ [], body) do
     if name == :context do

--- a/lib/ex_unit_fixtures/fixture_info.ex
+++ b/lib/ex_unit_fixtures/fixture_info.ex
@@ -10,11 +10,15 @@ defmodule ExUnitFixtures.FixtureInfo do
     the order that it accepts them as parameters.
   """
 
-  defstruct name: nil, func: nil, dep_names: []
+  defstruct name: nil, func: nil, dep_names: [], scope: :function
+
+  @type scope :: :test | :module
 
   @type t :: %__MODULE__{
     name: :atom,
     func: {:atom, :atom},
-    dep_names: [:atom]
+    dep_names: [:atom],
+    scope: scope
   }
+
 end

--- a/mix.exs
+++ b/mix.exs
@@ -50,9 +50,7 @@ defmodule ExUnitFixtures.Mixfile do
     [
       maintainers: ["Graeme Coupar <grambo@grambo.me.uk>"],
       licenses: ["MIT"],
-      links: %{"GitHub" => "https://github.com/obmarg/ex_unit_fixtures",
-               # TODO: Add doc link in here.
-               }
+      links: %{"GitHub" => "https://github.com/obmarg/ex_unit_fixtures"}
     ]
   end
 

--- a/test/ex_unit_fixtures/imp_test.exs
+++ b/test/ex_unit_fixtures/imp_test.exs
@@ -1,7 +1,8 @@
 defmodule ExUnitFixturesImpTest do
   use ExUnit.Case
 
-  alias ExUnitFixtures.{Imp, FixtureInfo}
+  alias ExUnitFixtures.Imp
+  alias ExUnitFixtures.FixtureInfo
 
   test "test_scoped_fixtures fails when given a missing fixture" do
     assert_raise RuntimeError, ~r/Could not find a fixture named test/, fn ->

--- a/test/ex_unit_fixtures/imp_test.exs
+++ b/test/ex_unit_fixtures/imp_test.exs
@@ -1,18 +1,30 @@
 defmodule ExUnitFixturesImpTest do
   use ExUnit.Case
 
-  alias ExUnitFixtures.Imp
-  
-  test "fixtures_for_context fails when given a missing fixture" do
+  alias ExUnitFixtures.{Imp, FixtureInfo}
+
+  test "test_scoped_fixtures fails when given a missing fixture" do
     assert_raise RuntimeError, ~r/Could not find a fixture named test/, fn ->
-      Imp.fixtures_for_context(%{fixtures: [:test]}, %{})
+      Imp.test_scoped_fixtures(%{fixtures: [:test]}, %{})
     end
   end
 
-  test "fixtures_for_context suggests other fixtures when missing" do
+  test "test_scoped_fixtures suggests other fixtures when missing" do
     assert_raise RuntimeError, ~r/Did you mean test\?$/, fn ->
-      Imp.fixtures_for_context(%{fixtures: [:tets]},
-                               %{test: :test, other: :other})
+      fixture_infos = %{test: %FixtureInfo{name: :test},
+                        other: %FixtureInfo{name: :other}}
+
+      Imp.test_scoped_fixtures(%{fixtures: [:tets]}, fixture_infos)
+    end
+  end
+
+  test "module level fixtures can not depend on test level fixtures" do
+    assert_raise RuntimeError, ~r/scoped to the test/, fn ->
+      fixture_infos = %{mod: %FixtureInfo{name: :mod, scope: :module,
+                                          dep_names: [:test]},
+                        test: %FixtureInfo{name: :test, scope: :test}}
+
+      Imp.module_scoped_fixtures(fixture_infos)
     end
   end
 

--- a/test/ex_unit_fixtures_test.exs
+++ b/test/ex_unit_fixtures_test.exs
@@ -28,8 +28,20 @@ defmodule ExunitFixturesTest do
     ref
   end
 
-  setup do
-    {:ok, %{setup_ran: true}}
+  deffixture module_fixture(), scope: :module do
+    :woo_modules
+  end
+
+  deffixture test_fixture_with_module_fixture(module_fixture) do
+    module_fixture
+  end
+
+  setup_all do
+    {:ok, %{setup_all_ran: true}}
+  end
+
+  setup context do
+    {:ok, %{setup_ran: true, setup_all_ran: context.setup_all_ran}}
   end
 
   test "deffixture generates a function that can create a fixture" do
@@ -80,5 +92,19 @@ defmodule ExunitFixturesTest do
   @tag fun_things: "Clowns"
   test "fixtures can access the test context", context do
     assert context.fixture_with_context == "Clowns"
+  end
+
+  @tag fixtures: [:module_fixture]
+  test "module level fixtures can be accessed", context do
+    assert context.module_fixture == :woo_modules
+  end
+
+  @tag fixtures: [:test_fixture_with_module_fixture]
+  test "test fixtures can depend on module level fixtures", context do
+    assert context.test_fixture_with_module_fixture == :woo_modules
+  end
+
+  test "other setup_all functions still run", context do
+    assert context.setup_all_ran
   end
 end


### PR DESCRIPTION
This PR implements module scoped fixtures.  These are fixtures that
will be created in a setup_all function and then presented to every
single test in the module.

This is done using the new 2nd argument to `deffixture`:

```
deffixture test, scope: :module do
end
```
