### PR TITLE
README now points at docs.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,6 @@
 # Contributing
 
-Contributions of any form to `ex_unit_fixtures` are welcome - thanks in advance
-for any.
+Contributions of any form to `ex_unit_fixtures` are welcome.
 
-If you'd like to submit code to `ex_unit_fixtures` please just make a pull
-request in github.
+- Bugs can be reported on github.
+- PRs are also welcome.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,12 @@ the tests context.
           [{:ex_unit_fixtures, "~> 0.1.0", only: [:test]}]
         end
 
-## Using ExUnit
+## Documentation
+
+The documentation can be found on hexdocs.pm:
+http://hexdocs.pm/ex_unit_fixtures/ExUnitFixtures.html
+
+## Example
 
 For example, lets say some of your tests required a model named `my_model`, you
 need to define the fixture using `deffixture` and then tag your test to say it
@@ -49,44 +54,5 @@ requires this fixture:
       end
     end
 
-#### Fixtures with dependencies
-
-Fixtures can also depend on other fixtures by naming a parameter after that
-fixture. For example, if you needed to setup a database instance before creating
-some models:
-
-    deffixture database do
-      # set up the database somehow...
-    end
-
-    deffixture my_model(database) do
-      # use the database to insert a model
-    end
-
-    @tag fixtures: [:my_model]
-    test "something" do
-      # Test
-    end
-
-In the sample above, we have 2 fixtures: one which creates the database and
-another which inserts a model into that database. The test function depends on
-`my_model` which depends on the database. ExUnitFixtures knows this, and takes
-care of setting up the database and passing it in to `my_model`.
-
-#### Tearing down Fixtures
-
-If you need to do some teardown work for a fixture you can use the ExUnit
-`on_exit` function:
-
-    defmodule TestWithTearDowns do
-      use ExUnitFixtures
-      use ExUnit.Case
-
-      deffixture database do
-        # Setup the database
-        on_exit fn ->
-          # Tear down the database
-          nil
-        end
-      end
-    end
+More details can be found in
+[the documentation](http://hexdocs.pm/ex_unit_fixtures/ExUnitFixtures.html).

--- a/lib/ex_unit_fixtures.ex
+++ b/lib/ex_unit_fixtures.ex
@@ -2,6 +2,9 @@ defmodule ExUnitFixtures do
   @moduledoc """
   A library for declaring & using test fixtures in ExUnit.
 
+  For an overview of it's purpose see the
+  [README](http://hexdocs.pm/ex_unit_fixtures/README.html).
+
   To use ExUnitFixtures, you should `use ExUnitFixtures` in your test case
   (before `use ExUnit.Case`), and then define your fixtures using
   `deffixture/3`. These fixtures can then be used by tagging your tests with the

--- a/mix.exs
+++ b/mix.exs
@@ -14,7 +14,7 @@ defmodule ExUnitFixtures.Mixfile do
      name: "ExUnitFixtures",
      source_url: "https://github.com/obmarg/ex_unit_fixtures",
      homepage_url: "https://github.com/obmarg/ex_unit_fixtures",
-     docs: [main: "README",
+     docs: [main: "ExUnitFixtures",
             extras: [{"README.md", [path: "README",
                                     title: "Read Me"]},
                      "CONTRIBUTING.md"]]]


### PR DESCRIPTION
This removes a bunch of the code from the README in favour of just
having it in the documentation.  It also updates the main page of the
documentation to be the ExUnitFixtures page, where I have documented
most of the stuff that was previously in the README.
