### PR TITLE
Implement autouse fixtures.

### DIFF
--- a/lib/ex_unit_fixtures.ex
+++ b/lib/ex_unit_fixtures.ex
@@ -61,8 +61,8 @@ defmodule ExUnitFixtures do
 
   Fixtures may optionally be provided with a scope:
 
-  - `:test` scoped fixtures will be created before a test and deleted afterwards.
-    This is the default scope for a fixture.
+  - `:test` scoped fixtures will be created before a test and deleted
+    afterwards. This is the default scope for a fixture.
   - `:module` scoped fixtures will be created at the start of a test module and
     passed to every single test in the module.
 
@@ -124,6 +124,8 @@ defmodule ExUnitFixtures do
   These options are supported:
 
   - `scope` controls the scope of fixtures. See Fixture Scoping for details.
+  - Passing `autouse: true` will cause a fixture to be passed to every test in
+    the module.
   """
   defmacro deffixture({name, info, params}, opts \\ [], body) do
     if name == :context do
@@ -139,6 +141,7 @@ defmodule ExUnitFixtures do
     end
 
     scope = Dict.get(opts, :scope, :function)
+    autouse = Dict.get(opts, :autouse, false)
 
     quote do
       def unquote({create_name, info, params}), unquote(body)
@@ -146,7 +149,8 @@ defmodule ExUnitFixtures do
       @fixtures %FixtureInfo{name: unquote(name),
                              func: {__MODULE__, unquote(create_name)},
                              dep_names: unquote(dep_names),
-                             scope: unquote(scope)}
+                             scope: unquote(scope),
+                             autouse: unquote(autouse)}
     end
   end
 

--- a/lib/ex_unit_fixtures/fixture_info.ex
+++ b/lib/ex_unit_fixtures/fixture_info.ex
@@ -8,9 +8,18 @@ defmodule ExUnitFixtures.FixtureInfo do
   - `func` - the function that implements this fixture, as `{module, func_name}`
   - `dep_names` - the names of any dependencies this function has as atoms, in
     the order that it accepts them as parameters.
+  - `scope` - the scope of the fixture. See `ExUnitFixtures` for more details.
+  - `autouse` - whether or not the fixture will automatically be used for all
+    tests.
   """
 
-  defstruct name: nil, func: nil, dep_names: [], scope: :function
+  defstruct [
+    name: nil,
+    func: nil,
+    dep_names: [],
+    scope: :function,
+    autouse: false
+  ]
 
   @type scope :: :test | :module
 
@@ -18,7 +27,8 @@ defmodule ExUnitFixtures.FixtureInfo do
     name: :atom,
     func: {:atom, :atom},
     dep_names: [:atom],
-    scope: scope
+    scope: scope,
+    autouse: boolean
   }
 
 end

--- a/lib/ex_unit_fixtures/imp.ex
+++ b/lib/ex_unit_fixtures/imp.ex
@@ -43,15 +43,22 @@ defmodule ExUnitFixtures.Imp do
   @spec test_scoped_fixtures(%{}, fixture_infos) :: fixtures
   def test_scoped_fixtures(context, fixture_infos) do
     module_fixtures = module_fixture_names(fixture_infos)
+    autouse_fixtures = for {_, f} <- fixture_infos, f.autouse, do: f.name
 
-    if context[:fixtures] do
+    fixtures = if context[:fixtures] do
+      Enum.uniq(autouse_fixtures ++ context[:fixtures])
+    else
+      autouse_fixtures
+    end
+
+    if length(fixtures) != 0 do
       existing_fixtures =
         context
           |> Dict.take(module_fixtures)
           |> Dict.put(:context, context)
 
       test_fixtures =
-        context.fixtures
+        fixtures
           |> list_difference(module_fixtures)
           |> create_fixtures(fixture_infos, existing_fixtures)
 

--- a/test/ex_unit_fixtures_test.exs
+++ b/test/ex_unit_fixtures_test.exs
@@ -36,6 +36,10 @@ defmodule ExunitFixturesTest do
     module_fixture
   end
 
+  deffixture autouse_fixture, autouse: true do
+    :automagic
+  end
+
   setup_all do
     {:ok, %{setup_all_ran: true}}
   end
@@ -106,5 +110,19 @@ defmodule ExunitFixturesTest do
 
   test "other setup_all functions still run", context do
     assert context.setup_all_ran
+  end
+
+  test "autouse fixture is used when no fixtures requested", context do
+    assert context.autouse_fixture == :automagic
+  end
+
+  @tag fixtures: [:simple]
+  test "autouse fixture is used when a fixture is requested", context do
+    assert context.autouse_fixture == :automagic
+  end
+
+  @tag fixtures: [:autouse_fixture]
+  test "asking for an autouse fixture is ok", context do
+    assert context.autouse_fixture == :automagic
   end
 end


### PR DESCRIPTION
These are fixtures that will automatically be passed in to every test,
much like module fixtures, except they will be different for each of the
tests.
