### PR TITLE
Add fixture modules.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,12 @@ this.  These work well for simpler cases, but have a couple of drawbacks:
 - The setup code will run for all tests, even if the test does not need it.
 - Sharing setup code between modules requires extracting it out into a function.
 
-ExUnitFixtures attempts to solve that. It provides a way to define a fixture,
-which can be any bit of setup code that a test might require. Each of the tests
-in a file can then list the fixtures they require and have them injected into
-the tests context.
+Neither of these are deal breakers but we can do better.
+
+ExUnitFixtures attempts to do so. It provides a way to define a fixture, which
+can be any bit of setup code or data that a test might require. Each of the
+tests in a file can then list the fixtures they require and have them injected
+into a tests context as appropriate.
 
 ## Installation
 

--- a/lib/ex_unit_fixtures.ex
+++ b/lib/ex_unit_fixtures.ex
@@ -2,8 +2,7 @@ defmodule ExUnitFixtures do
   @moduledoc """
   A library for declaring & using test fixtures in ExUnit.
 
-  For an overview of it's purpose see the
-  [README](http://hexdocs.pm/ex_unit_fixtures/README.html).
+  For an overview of it's purpose see the [README](README.html).
 
   To use ExUnitFixtures, you should `use ExUnitFixtures` in your test case
   (before `use ExUnit.Case`), and then define your fixtures using

--- a/lib/ex_unit_fixtures.ex
+++ b/lib/ex_unit_fixtures.ex
@@ -93,41 +93,8 @@ defmodule ExUnitFixtures do
 
   ## Sharing Fixtures Amongst Test Cases.
 
-  Fixtures are fully compatible with `ExUnit.CaseTemplate` - this is the current
-  recommended way to share some fixtures among a number of files. Simply defined
-  your fixtures in an ExUnit.CaseTemplate, and then any file that imports that
-  CaseTemplate with use will have access to all the fixtures defined within. For
-  example:
-
-      defmodule MyFixtures do
-        use ExUnitFixtures
-        use ExUnit.CaseTemplate
-
-        deffixture database do
-          # Setup the database.
-          %{database: :db}
-        end
-      end
-
-      def Tests do
-        use MyFixtures
-        use ExUnit.Case
-
-        @tag fixtures: [:database]
-        test "that we have a database", %{database: db} do
-          assert db == :db
-        end
-      end
-
-  Currently a test case can't use both fixtures imported from a CaseTemplate
-  _and_ locally defined fixtures, though there are plans to add support for that
-  in the future.
-
-  Note: The example above will work as is if both modules are defined in the
-  same file. However, you'll need to do some work to ensure your CaseTemplate is
-  loaded when your tests are running. You can do this using the `Code.load_file`
-  function in your `test_helper.exs` file, [as described in this stack overflow
-  answer](http://stackoverflow.com/a/30652675/589746).
+  It is possible to share fixtures among test cases using
+  `ExUnitFixtures.FixtureModule`.
   """
 
   alias ExUnitFixtures.FixtureDef

--- a/lib/ex_unit_fixtures/fixture_def.ex
+++ b/lib/ex_unit_fixtures/fixture_def.ex
@@ -1,6 +1,6 @@
-defmodule ExUnitFixtures.FixtureInfo do
+defmodule ExUnitFixtures.FixtureDef do
   @moduledoc """
-  Provides a struct that stores information about a fixture.
+  A struct that stores information about a fixture definition.
 
   ### Fields
 
@@ -11,6 +11,10 @@ defmodule ExUnitFixtures.FixtureInfo do
   - `scope` - the scope of the fixture. See `ExUnitFixtures` for more details.
   - `autouse` - whether or not the fixture will automatically be used for all
     tests.
+  - `qualified_name` - the name of the fixture & the module it's defined in.
+  - `hidden` - whether or not the fixture is "hidden" in the current scope.
+    This happens when a fixture has been shadowed by another fixture of the same
+    name.
   """
 
   defstruct [
@@ -18,7 +22,10 @@ defmodule ExUnitFixtures.FixtureInfo do
     func: nil,
     dep_names: [],
     scope: :function,
-    autouse: false
+    autouse: false,
+    qualified_name: nil,
+    qualified_dep_names: nil,
+    hidden: false
   ]
 
   @type scope :: :test | :module
@@ -28,7 +35,10 @@ defmodule ExUnitFixtures.FixtureInfo do
     func: {:atom, :atom},
     dep_names: [:atom],
     scope: scope,
-    autouse: boolean
+    autouse: boolean,
+    qualified_name: :atom,
+    qualified_dep_names: [:atom],
+    hidden: boolean
   }
 
 end

--- a/lib/ex_unit_fixtures/fixture_module.ex
+++ b/lib/ex_unit_fixtures/fixture_module.ex
@@ -42,24 +42,24 @@ defmodule ExUnitFixtures.FixtureModule do
   current module or importing modules will only be able to get the overriding
   fixture.
 
-     defmodule MyFixtures do
-       use ExUnitFixtures.FixtureModule
+      defmodule MyFixtures do
+        use ExUnitFixtures.FixtureModule
 
-       deffixture user do
-         make_user()
-       end
-     end
+        deffixture user do
+          make_user()
+        end
+      end
 
-     defmodule InactiveUserTests do
-       deffixture user(user) do
-         %{user | active: false}
-       end
+      defmodule InactiveUserTests do
+        deffixture user(user) do
+          %{user | active: false}
+        end
 
-       @tag fixtures: [:user]
-       test "that user is inactive", %{user: user} do
-         assert user.active == false
-       end
-     end
+        @tag fixtures: [:user]
+        test "that user is inactive", %{user: user} do
+          assert user.active == false
+        end
+      end
 
   #### Loading Fixture Code
 
@@ -100,7 +100,8 @@ defmodule ExUnitFixtures.FixtureModule do
   end
 
   @doc """
-  Body of the nested __using__ func in any module that has used `FixtureModule`.
+  Body of the nested `__using__` func in any module that has used
+  `FixtureModule`.
   """
   def register_fixtures(fixture_module, _opts) do
     quote do

--- a/lib/ex_unit_fixtures/fixture_module.ex
+++ b/lib/ex_unit_fixtures/fixture_module.ex
@@ -64,10 +64,10 @@ defmodule ExUnitFixtures.FixtureModule do
   #### Loading Fixture Code
 
   Note: The example above will work if both modules are defined in the same
-  file. If not, however, you'll need to do some work to ensure your CaseTemplate is
-  loaded when your tests are running. You can do this using the `Code.load_file`
-  function in your `test_helper.exs` file, [as described in this stack overflow
-  answer](http://stackoverflow.com/a/30652675/589746).
+  file. If not, however, you'll need to do some work to ensure your CaseTemplate
+  is loaded when your tests are running. You can do this using the
+  `Code.load_file` function in your `test_helper.exs` file, [as described in
+  this stack overflow answer](http://stackoverflow.com/a/30652675/589746).
   """
 
   defmacro __using__(_opts) do

--- a/lib/ex_unit_fixtures/fixture_module.ex
+++ b/lib/ex_unit_fixtures/fixture_module.ex
@@ -1,0 +1,105 @@
+defmodule ExUnitFixtures.FixtureModule do
+  @moduledoc """
+  Sets up a module as an importable module of fixtures.
+
+  This module can be used in any module that defines common fixtures to be
+  shared amongst many tests.
+
+  By using `ExUnitFixtures.FixtureModule` a module will become a fixture module.
+  A fixture module can be used by other test cases, as well as imported into
+  other fixture modules.
+
+  For example:
+
+      defmodule MyFixtures do
+        use ExUnitFixtures.FixtureModule
+
+        deffixture database do
+          %{db: :db}
+        end
+
+        deffixture user(database) do
+          %{user: user}
+        end
+      end
+
+      defmodule MyTests do
+        use ExUnitFixtures
+        use MyFixtures
+        use ExUnit.Case
+
+        @tag fixtures: [:user]
+        test "that we have a user", %{user: user} do
+          assert user == :user
+        end
+      end
+
+  #### Overriding Fixtures
+
+  When importing fixtures into a module it's possible to override some of those
+  fixtures, by calling deffixture with an already used name. The overriding
+  fixture may depend on the existing fixture, but any other fixture in the
+  current module or importing modules will only be able to get the overriding
+  fixture.
+
+     defmodule MyFixtures do
+       use ExUnitFixtures.FixtureModule
+
+       deffixture user do
+         make_user()
+       end
+     end
+
+     defmodule InactiveUserTests do
+       deffixture user(user) do
+         %{user | active: false}
+       end
+
+       test "that user is inactive", %{user: user} do
+         assert user.active == false
+       end
+     end
+  """
+
+  defmacro __using__(_opts) do
+    quote do
+      Module.register_attribute __MODULE__, :fixtures, accumulate: true
+      import ExUnitFixtures
+
+      @before_compile ExUnitFixtures.FixtureModule
+
+      Module.register_attribute(__MODULE__,
+                                :fixture_modules,
+                                accumulate: true)
+
+      defmacro __using__(opts) do
+        ExUnitFixtures.FixtureModule.register_fixtures(__MODULE__, opts)
+      end
+    end
+  end
+
+  defmacro __before_compile__(_) do
+    quote do
+      @fixtures_ ExUnitFixtures.Imp.Preprocessing.preprocess_fixtures(
+        @fixtures, @fixture_modules
+      )
+
+      def fixtures do
+        @fixtures_
+      end
+    end
+  end
+
+  @doc """
+  Body of the nested __using__ func in any module that has used `FixtureModule`.
+  """
+  def register_fixtures(fixture_module, _opts) do
+    quote do
+      Module.register_attribute(__MODULE__,
+                                :fixture_modules,
+                                accumulate: true)
+
+      @fixture_modules unquote(fixture_module)
+    end
+  end
+end

--- a/lib/ex_unit_fixtures/fixture_module.ex
+++ b/lib/ex_unit_fixtures/fixture_module.ex
@@ -55,6 +55,7 @@ defmodule ExUnitFixtures.FixtureModule do
          %{user | active: false}
        end
 
+       @tag fixtures: [:user]
        test "that user is inactive", %{user: user} do
          assert user.active == false
        end

--- a/lib/ex_unit_fixtures/fixture_module.ex
+++ b/lib/ex_unit_fixtures/fixture_module.ex
@@ -59,6 +59,14 @@ defmodule ExUnitFixtures.FixtureModule do
          assert user.active == false
        end
      end
+
+  #### Loading Fixture Code
+
+  Note: The example above will work if both modules are defined in the same
+  file. If not, however, you'll need to do some work to ensure your CaseTemplate is
+  loaded when your tests are running. You can do this using the `Code.load_file`
+  function in your `test_helper.exs` file, [as described in this stack overflow
+  answer](http://stackoverflow.com/a/30652675/589746).
   """
 
   defmacro __using__(_opts) do

--- a/lib/ex_unit_fixtures/imp/preprocessing.ex
+++ b/lib/ex_unit_fixtures/imp/preprocessing.ex
@@ -1,0 +1,132 @@
+defmodule ExUnitFixtures.Imp.Preprocessing do
+  @moduledoc """
+  Provides functions that pre-process fixtures at compile time.
+
+  Most of the functions provide some sort of transformation or validation
+  process that we need to do on fixtures at compile time.
+  """
+
+  alias ExUnitFixtures.FixtureDef
+
+  @type fixture_dict :: %{atom: FixtureDef.t}
+
+  @doc """
+  Checks there are no fixtures named `fixture_name` already in `fixtures`.
+
+  Raises an error if any clashes are found.
+  """
+  def check_clashes(fixture_name, fixtures) do
+    if Enum.find(fixtures, fn f -> f.name == fixture_name end) != nil do
+      raise "There is already a fixture named #{fixture_name} in this module."
+    end
+  end
+
+  @doc """
+  Pre-processes the defined & imported fixtures in a module.
+
+  This will take the list of fixtures that have been defined, resolve their
+  dependencies and produce a map of those dependencies merged with any imported
+  dependencies.
+
+  The map will use fully qualified fixture names for keys.
+  """
+  @spec preprocess_fixtures([FixtureDef.t],
+                            [:atom] | fixture_dict) :: fixture_dict
+  def preprocess_fixtures(local_fixtures,
+                          imported_modules) when is_list(imported_modules) do
+    imported_fixtures = fixtures_from_modules(imported_modules)
+    preprocess_fixtures(local_fixtures, imported_fixtures)
+  end
+
+  def preprocess_fixtures(local_fixtures, imported_fixtures) do
+    resolved_locals =
+      for f <- resolve_dependencies(local_fixtures, imported_fixtures),
+      into: %{},
+      do: {f.qualified_name, f}
+
+    local_fixtures
+    |> hide_fixtures(imported_fixtures)
+    |> Dict.merge(resolved_locals)
+  end
+
+  @doc """
+  Resolves dependencies for fixtures in a module.
+
+  Replaces the unqualified dep_names in a FixtureDef with qualified names.
+  """
+  @spec resolve_dependencies([FixtureDef.t], fixture_dict) :: [FixtureDef.t]
+  def resolve_dependencies(local_fixtures, imported_fixtures) do
+    visible_fixtures =
+      for {_, f} <- imported_fixtures,
+      f.hidden == false,
+      into: %{},
+      do: {f.name, f}
+
+    all_fixtures = Map.merge(
+      visible_fixtures,
+      (for f <- local_fixtures, into: %{}, do: {f.name, f})
+    )
+
+    for fixture <- local_fixtures do
+      resolved_deps = for dep <- fixture.dep_names do
+        resolve_dependency(dep, fixture, all_fixtures, visible_fixtures)
+      end
+      %{fixture | qualified_dep_names: resolved_deps}
+    end
+  end
+
+  @spec resolve_dependency(:atom, FixtureDef.t,
+                           fixture_dict, fixture_dict) :: :atom
+  defp resolve_dependency(:context, _, _, _) do
+    # Special case the ExUnit.Case context
+    :context
+  end
+  defp resolve_dependency(dep_name, fixture,
+                          all_fixtures, visible_fixtures) do
+    resolved_dep = if dep_name == fixture.name do
+      visible_fixtures[dep_name]
+    else
+      all_fixtures[dep_name]
+    end
+    unless resolved_dep do
+      ExUnitFixtures.Imp.report_missing_dep(dep_name,
+                                            all_fixtures |> Map.values)
+    end
+    validate_dep(fixture, resolved_dep)
+    resolved_dep.qualified_name
+  end
+
+  @spec hide_fixtures([FixtureDef.t], fixture_dict) :: fixture_dict
+  defp hide_fixtures(local_fixtures, imported_fixtures) do
+    # Hides any fixtures in imported_fixtures that have been shadowed by
+    # local_fixtures.
+    names_to_hide = for f <- local_fixtures, into: MapSet.new, do: f.name
+
+    for {name, f} <- imported_fixtures, into: %{} do
+      if Set.member?(names_to_hide, f.name) do
+        {name, %{f | hidden: true}}
+      else
+        {name, f}
+      end
+    end
+  end
+
+  @spec fixtures_from_modules([:atom]) :: fixture_dict
+  defp fixtures_from_modules(modules) do
+    imported_fixtures = for module <- modules, do: module.fixtures
+    Enum.reduce imported_fixtures, %{}, &Dict.merge/2
+  end
+
+
+  @spec validate_dep(FixtureDef.t, FixtureDef.t) :: any
+  defp validate_dep(%{scope: :module, name: fixture_name},
+                    %{scope: :test, name: dep_name}) do
+    raise """
+      Mis-matched scopes:
+      #{fixture_name} is scoped to the test module
+      #{dep_name} is scoped to the test.
+      But #{fixture_name} depends on #{dep_name}
+      """
+  end
+  defp validate_dep(_fixture, _resolved_dep), do: :ok
+end

--- a/lib/ex_unit_fixtures/imp/preprocessing.ex
+++ b/lib/ex_unit_fixtures/imp/preprocessing.ex
@@ -58,7 +58,7 @@ defmodule ExUnitFixtures.Imp.Preprocessing do
   def resolve_dependencies(local_fixtures, imported_fixtures) do
     visible_fixtures =
       for {_, f} <- imported_fixtures,
-      f.hidden == false,
+      !f.hidden,
       into: %{},
       do: {f.name, f}
 
@@ -118,7 +118,7 @@ defmodule ExUnitFixtures.Imp.Preprocessing do
   end
 
 
-  @spec validate_dep(FixtureDef.t, FixtureDef.t) :: any
+  @spec validate_dep(FixtureDef.t, FixtureDef.t) :: :ok | no_return
   defp validate_dep(%{scope: :module, name: fixture_name},
                     %{scope: :test, name: dep_name}) do
     raise """
@@ -126,7 +126,7 @@ defmodule ExUnitFixtures.Imp.Preprocessing do
       #{fixture_name} is scoped to the test module
       #{dep_name} is scoped to the test.
       But #{fixture_name} depends on #{dep_name}
-      """
+    """
   end
   defp validate_dep(_fixture, _resolved_dep), do: :ok
 end

--- a/test/ex_unit_fixtures/imp_test.exs
+++ b/test/ex_unit_fixtures/imp_test.exs
@@ -2,7 +2,7 @@ defmodule ExUnitFixturesImpTest do
   use ExUnit.Case
 
   alias ExUnitFixtures.Imp
-  alias ExUnitFixtures.FixtureInfo
+  alias ExUnitFixtures.FixtureDef
 
   test "test_scoped_fixtures fails when given a missing fixture" do
     assert_raise RuntimeError, ~r/Could not find a fixture named test/, fn ->
@@ -12,21 +12,10 @@ defmodule ExUnitFixturesImpTest do
 
   test "test_scoped_fixtures suggests other fixtures when missing" do
     assert_raise RuntimeError, ~r/Did you mean test\?$/, fn ->
-      fixture_infos = %{test: %FixtureInfo{name: :test},
-                        other: %FixtureInfo{name: :other}}
+      fixture_defs = %{test: %FixtureDef{name: :test},
+                        other: %FixtureDef{name: :other}}
 
-      Imp.test_scoped_fixtures(%{fixtures: [:tets]}, fixture_infos)
+      Imp.test_scoped_fixtures(%{fixtures: [:tets]}, fixture_defs)
     end
   end
-
-  test "module level fixtures can not depend on test level fixtures" do
-    assert_raise RuntimeError, ~r/scoped to the test/, fn ->
-      fixture_infos = %{mod: %FixtureInfo{name: :mod, scope: :module,
-                                          dep_names: [:test]},
-                        test: %FixtureInfo{name: :test, scope: :test}}
-
-      Imp.module_scoped_fixtures(fixture_infos)
-    end
-  end
-
 end

--- a/test/ex_unit_fixtures_test.exs
+++ b/test/ex_unit_fixtures_test.exs
@@ -53,9 +53,12 @@ defmodule ExunitFixturesTest do
   end
 
   test "deffixture adds the fixture to @fixtures" do
-    expected = %ExUnitFixtures.FixtureInfo{name: :simple,
-                                           func: {ExunitFixturesTest,
-                                                  :fixture_create_simple}}
+    expected = %ExUnitFixtures.FixtureDef{
+      name: :simple,
+      func: {ExunitFixturesTest,
+             :fixture_create_simple},
+      qualified_name: :"Elixir.ExunitFixturesTest.simple"
+    }
     assert expected in @fixtures
   end
 

--- a/test/fixture_module_test.exs
+++ b/test/fixture_module_test.exs
@@ -1,0 +1,77 @@
+defmodule FirstFixtures do
+  use ExUnitFixtures.FixtureModule
+
+  deffixture overridable do
+    :initial
+  end
+
+  deffixture overriable2 do
+    :from_first_fixtures
+  end
+end
+
+defmodule Fixtures do
+  use ExUnitFixtures.FixtureModule
+  use FirstFixtures
+
+  deffixture simple do
+    :simple
+  end
+
+  deffixture fixture_that_uses_overridable(overridable) do
+    overridable
+  end
+
+  deffixture overridable(overridable) do
+    {:second, overridable}
+  end
+
+  deffixture overridable2 do
+    :from_fixtures
+  end
+end
+
+defmodule FixtureModuleTest do
+  use Fixtures
+  use ExUnitFixtures
+  use ExUnit.Case
+
+  deffixture overridable2(overridable2) do
+    {:in_test, overridable2}
+  end
+
+  test "that a test without fixtures works", context do
+    refute Dict.has_key?(context, :simple)
+  end
+
+  test "that we have an imported_fixtures module attribute" do
+    assert length(@fixture_modules) > 0
+  end
+
+  @tag fixtures: [:simple]
+  test "that we can import fixtures from the fixture module", context do
+    assert context.simple == :simple
+  end
+
+  @tag fixtures: [:overridable]
+  test "we can override fixtures from other modules", context do
+    assert context.overridable == {:second, :initial}
+  end
+
+  @tag fixtures: [:fixture_that_uses_overridable]
+  test "depending on an overridden fixture gets the current version", context do
+    assert context.fixture_that_uses_overridable == {:second, :initial}
+  end
+
+  @tag fixtures: [:overridable2]
+  test "that we can override locally", context do
+    {first, _} = context.overridable2
+    assert first == :in_test
+  end
+
+  @tag fixtures: [:overridable2]
+  test "that we can hide fixtures without using them", context do
+    {_, second} = context.overridable2
+    assert second == :from_fixtures
+  end
+end

--- a/test/imp/preprocessing_test.exs
+++ b/test/imp/preprocessing_test.exs
@@ -30,11 +30,11 @@ defmodule PreprocessingTest do
 
     assert output[:"Test.fixture_one"].dep_names == []
     assert output[:"Test.fixture_one"].qualified_dep_names == []
-    assert output[:"Test.fixture_one"].hidden == false
+    refute output[:"Test.fixture_one"].hidden
 
     assert output[:"Test.fixture_two"].dep_names == [:fixture_one]
     assert output[:"Test.fixture_two"].qualified_dep_names == [:"Test.fixture_one"]
-    assert output[:"Test.fixture_two"].hidden == false
+    refute output[:"Test.fixture_two"].hidden
   end
 
   test "preprocess_fixtures with an imported module and no clash" do
@@ -54,12 +54,12 @@ defmodule PreprocessingTest do
     assert output[:"Test.fixture_two"] != nil
     assert Dict.size(output) == 2
 
-    assert output[:"Fixtures.fixture_one"].hidden == false
+    refute output[:"Fixtures.fixture_one"].hidden
 
     assert output[:"Test.fixture_two"].qualified_dep_names == [
       :"Fixtures.fixture_one"
     ]
-    assert output[:"Test.fixture_two"].hidden == false
+    refute output[:"Test.fixture_two"].hidden
   end
 
   test "preprocess_fixtures hides clashes" do
@@ -79,12 +79,12 @@ defmodule PreprocessingTest do
     assert output[:"Test.fixture_one"] != nil
     assert Dict.size(output) == 2
 
-    assert output[:"Fixtures.fixture_one"].hidden == true
+    assert output[:"Fixtures.fixture_one"].hidden
 
     assert output[:"Test.fixture_one"].qualified_dep_names == [
       :"Fixtures.fixture_one"
     ]
-    assert output[:"Test.fixture_one"].hidden == false
+    refute output[:"Test.fixture_one"].hidden
   end
 
   test "resolve_dependencies with missing deps fails" do

--- a/test/imp/preprocessing_test.exs
+++ b/test/imp/preprocessing_test.exs
@@ -1,0 +1,115 @@
+defmodule PreprocessingTest do
+  use ExUnit.Case
+
+  alias ExUnitFixtures.FixtureDef
+
+  import ExUnitFixtures.Imp.Preprocessing
+
+  test "check_clashes errors if there's a clash" do
+    assert_raise RuntimeError, fn ->
+      check_clashes(:test, [%FixtureDef{name: :test},
+                            %FixtureDef{name: :nottest}])
+    end
+  end
+
+  test "check_clashes passes if there's not a clash" do
+    check_clashes(:test, [%FixtureDef{name: :nottest}])
+  end
+
+  test "preprocess_fixtures with no imported modules" do
+    input = [%FixtureDef{name: :fixture_one,
+                         qualified_name: :"Test.fixture_one"},
+             %FixtureDef{name: :fixture_two,
+                         dep_names: [:fixture_one],
+                         qualified_name: :"Test.fixture_two"}]
+    output = preprocess_fixtures(input, [])
+
+    assert output[:"Test.fixture_one"] != nil
+    assert output[:"Test.fixture_two"] != nil
+    assert Dict.size(output) == 2
+
+    assert output[:"Test.fixture_one"].dep_names == []
+    assert output[:"Test.fixture_one"].qualified_dep_names == []
+    assert output[:"Test.fixture_one"].hidden == false
+
+    assert output[:"Test.fixture_two"].dep_names == [:fixture_one]
+    assert output[:"Test.fixture_two"].qualified_dep_names == [:"Test.fixture_one"]
+    assert output[:"Test.fixture_two"].hidden == false
+  end
+
+  test "preprocess_fixtures with an imported module and no clash" do
+    imported_fixtures = %{
+      :"Fixtures.fixture_one" => %FixtureDef{
+        name: :fixture_one,
+        qualified_name: :"Fixtures.fixture_one"
+      }
+    }
+    local_fixtures = [%FixtureDef{name: :fixture_two,
+                                  dep_names: [:fixture_one],
+                                  qualified_name: :"Test.fixture_two"}]
+
+    output = preprocess_fixtures(local_fixtures, imported_fixtures)
+
+    assert output[:"Fixtures.fixture_one"] != nil
+    assert output[:"Test.fixture_two"] != nil
+    assert Dict.size(output) == 2
+
+    assert output[:"Fixtures.fixture_one"].hidden == false
+
+    assert output[:"Test.fixture_two"].qualified_dep_names == [
+      :"Fixtures.fixture_one"
+    ]
+    assert output[:"Test.fixture_two"].hidden == false
+  end
+
+  test "preprocess_fixtures hides clashes" do
+    imported_fixtures = %{
+      :"Fixtures.fixture_one" => %FixtureDef{
+        name: :fixture_one,
+        qualified_name: :"Fixtures.fixture_one"
+      }
+    }
+    local_fixtures = [%FixtureDef{name: :fixture_one,
+                                  dep_names: [:fixture_one],
+                                  qualified_name: :"Test.fixture_one"}]
+
+    output = preprocess_fixtures(local_fixtures, imported_fixtures)
+
+    assert output[:"Fixtures.fixture_one"] != nil
+    assert output[:"Test.fixture_one"] != nil
+    assert Dict.size(output) == 2
+
+    assert output[:"Fixtures.fixture_one"].hidden == true
+
+    assert output[:"Test.fixture_one"].qualified_dep_names == [
+      :"Fixtures.fixture_one"
+    ]
+    assert output[:"Test.fixture_one"].hidden == false
+  end
+
+  test "resolve_dependencies with missing deps fails" do
+    assert_raise RuntimeError, ~r/Could not find a fixture named missing/, fn ->
+      resolve_dependencies(
+        [%FixtureDef{name: :test, dep_names: [:missing]}], %{}
+      )
+    end
+  end
+
+  test "resolve_dependencies suggests other fixtures when missing" do
+    assert_raise RuntimeError, ~r/Did you mean test\?$/, fn ->
+      resolve_dependencies(
+        [%FixtureDef{name: :test, dep_names: [:missing]}], %{}
+      )
+    end
+  end
+
+  test "resolve_dependencies errors if module scope depends on test scope" do
+    fixture_defs = [%FixtureDef{name: :mod, scope: :module,
+                                dep_names: [:test]},
+                    %FixtureDef{name: :test, scope: :test}]
+
+    assert_raise RuntimeError, ~r/scoped to the test/, fn ->
+      resolve_dependencies(fixture_defs, %{})
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the concept of a "fixture module".  Fixtures that are
declared in a fixture module can be imported into other modules via the
`use` macro.

A fixture module is created via `use ExUnitFixtures.FixtureModule`
inside a module.  This allows it to be used itself.

For more details, see the documentation in ExUnit.FixtureModule.
