### PR TITLE
Fix calls to `on_exit` in fixture module. (Fixes #17)

### DIFF
--- a/lib/ex_unit_fixtures/fixture_module.ex
+++ b/lib/ex_unit_fixtures/fixture_module.ex
@@ -74,6 +74,7 @@ defmodule ExUnitFixtures.FixtureModule do
     quote do
       Module.register_attribute __MODULE__, :fixtures, accumulate: true
       import ExUnitFixtures
+      import ExUnit.Callbacks, only: [on_exit: 2, on_exit: 1]
 
       @before_compile ExUnitFixtures.FixtureModule
 

--- a/test/auto_load_tests/fixtures.exs
+++ b/test/auto_load_tests/fixtures.exs
@@ -3,6 +3,11 @@ defmodule AutoLoadFixtures do
   use ExUnitFixtures.AutoImport
 
   deffixture not_top_level_fixture do
+
+    on_exit fn ->
+      1
+    end
+
     :not_top
   end
 


### PR DESCRIPTION
Calling `use ExUnitFixtures.FixtureModule` should import the `on_exit`
macro from ExUnit.Callbacks.
