### PR TITLE
Raise a useful error when forget to start server.

### DIFF
--- a/lib/ex_unit_fixtures/imp/module_store.ex
+++ b/lib/ex_unit_fixtures/imp/module_store.ex
@@ -29,6 +29,8 @@ defmodule ExUnitFixtures.Imp.ModuleStore do
   """
   @spec find_file(String.t) :: [:atom]
   def find_file(filename) do
+    check_server_running
+
     filename = Path.absname(filename)
     Agent.get __MODULE__, fn state ->
       for {module, mod_file} <- state, mod_file == filename, do: module
@@ -40,6 +42,8 @@ defmodule ExUnitFixtures.Imp.ModuleStore do
   """
   @spec find_module(:atom) :: String.t
   def find_module(search_module) do
+    check_server_running
+
     Agent.get(__MODULE__, fn state ->
       for {module, mod_file} <- state, search_module == module, do: mod_file
     end)


### PR DESCRIPTION
Forgot to add some calls to check_server_running in the module store
implementation leading to some not so useful errors in certain
circumstances.

Did attempt to add some Application.ensure_all_started calls in fixture
modules but this didn't work out - ExUnitFixtures loads fixture modules
on startup so this lead to an annoying deadlock.

Fixes #16
