### PR TITLE
ExUnitFixtures.AutoImport is now default behaviour.

### DIFF
--- a/lib/ex_unit_fixtures/fixture_module.ex
+++ b/lib/ex_unit_fixtures/fixture_module.ex
@@ -84,6 +84,10 @@ defmodule ExUnitFixtures.FixtureModule do
 
       ExUnitFixtures.Imp.ModuleStore.register(__MODULE__, __ENV__.file)
 
+      if Application.get_env(:ex_unit_fixtures, :auto_import) do
+        use ExUnitFixtures.AutoImport
+      end
+
       defmacro __using__(opts) do
         ExUnitFixtures.FixtureModule.register_fixtures(__MODULE__, opts)
       end
@@ -93,7 +97,7 @@ defmodule ExUnitFixtures.FixtureModule do
   defmacro __before_compile__(_) do
     quote do
       @fixtures_ ExUnitFixtures.Imp.Preprocessing.preprocess_fixtures(
-        @fixtures, @fixture_modules
+        @fixtures, Enum.uniq(@fixture_modules)
       )
 
       def fixtures do

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,8 @@ defmodule ExUnitFixtures.Mixfile do
   # Type "mix help compile.app" for more information
   def application do
     [applications: [:logger],
-     mod: {ExUnitFixtures, []}]
+     mod: {ExUnitFixtures, []},
+     env: [auto_import: true, auto_load: true]]
   end
 
   # Dependencies can be Hex packages:

--- a/test/auto_load_tests/auto_load_test.exs
+++ b/test/auto_load_tests/auto_load_test.exs
@@ -1,6 +1,5 @@
 defmodule AutoLoadTest do
   use ExUnitFixtures
-  use ExUnitFixtures.AutoImport
   use ExUnit.Case
 
   deffixture local(fixture_that_uses_top) do

--- a/test/auto_load_tests/fixtures.exs
+++ b/test/auto_load_tests/fixtures.exs
@@ -1,6 +1,5 @@
 defmodule AutoLoadFixtures do
   use ExUnitFixtures.FixtureModule
-  use ExUnitFixtures.AutoImport
 
   deffixture not_top_level_fixture do
 


### PR DESCRIPTION
This updates ExUnitFixtures & ExUnitFixtures.FixtureModule to both
automatically `use ExUnitFixtures.AutoImport` by default.  This should
make things easier for most use cases where auto import is to be used,
while not causing any harm if people don't actually create
`fixtures.exs` files.

In the event that people do want to create `fixtures.exs` files, they
can always disable this via the application configuration.

This also updates the automatic loading of fixtures.exs files to be
configurable.

Fixes #18
