### PR TITLE
Correct default scope to :test not :function.

### DIFF
--- a/lib/ex_unit_fixtures.ex
+++ b/lib/ex_unit_fixtures.ex
@@ -217,7 +217,7 @@ defmodule ExUnitFixtures do
       dep_name
     end
 
-    scope = Dict.get(opts, :scope, :function)
+    scope = Dict.get(opts, :scope, :test)
     autouse = Dict.get(opts, :autouse, false)
 
     quote do

--- a/lib/ex_unit_fixtures/fixture_def.ex
+++ b/lib/ex_unit_fixtures/fixture_def.ex
@@ -21,7 +21,7 @@ defmodule ExUnitFixtures.FixtureDef do
     name: nil,
     func: nil,
     dep_names: [],
-    scope: :function,
+    scope: :test,
     autouse: false,
     qualified_name: nil,
     qualified_dep_names: nil,

--- a/lib/ex_unit_fixtures/imp.ex
+++ b/lib/ex_unit_fixtures/imp.ex
@@ -145,7 +145,7 @@ defmodule ExUnitFixtures.Imp do
 
   # Creates a fixture from it's fixture_info & deps, then inserts it into the
   # created_fixtures map.
-  @spec create_fixture(:atom, %{}) :: term
+  @spec create_fixture(FixtureDef.t, %{}) :: term
   defp create_fixture(fixture_info, created_fixtures) do
 
     args = for dep_name <- fixture_info.dep_names do

--- a/lib/ex_unit_fixtures/imp/preprocessing.ex
+++ b/lib/ex_unit_fixtures/imp/preprocessing.ex
@@ -117,11 +117,12 @@ defmodule ExUnitFixtures.Imp.Preprocessing do
     Enum.reduce imported_fixtures, %{}, &Dict.merge/2
   end
 
-
   @spec validate_dep(FixtureDef.t, FixtureDef.t) :: :ok | no_return
+  defp validate_dep(fixture, resolved_dependency)
   defp validate_dep(%{scope: :module, name: fixture_name},
                     %{scope: :test, name: dep_name}) do
     raise """
+
       Mis-matched scopes:
       #{fixture_name} is scoped to the test module
       #{dep_name} is scoped to the test.

--- a/test/compile_failure_files/module_dep_on_test_fixture_case.exs
+++ b/test/compile_failure_files/module_dep_on_test_fixture_case.exs
@@ -1,0 +1,10 @@
+defmodule ModuleDepOnTestFixture do
+  use ExUnitFixtures
+  use ExUnit.Case
+
+  deffixture test_fixture do
+  end
+
+  deffixture module_fixture(test_fixture), scope: :module do
+  end
+end

--- a/test/compile_failure_files/module_dep_on_test_fixture_module.exs
+++ b/test/compile_failure_files/module_dep_on_test_fixture_module.exs
@@ -1,0 +1,9 @@
+defmodule ModuleDepOnTestFixture do
+  use ExUnitFixtures.FixtureModule
+
+  deffixture test_fixture do
+  end
+
+  deffixture module_fixture(test_fixture), scope: :module do
+  end
+end

--- a/test/compile_failure_test.exs
+++ b/test/compile_failure_test.exs
@@ -1,0 +1,19 @@
+defmodule TestCompileFailures do
+  use ExUnit.Case
+
+  test "module fixtures can't depend on test fixtures in test case" do
+    assert_raise RuntimeError, ~r/Mis-matched scopes/, fn ->
+      load_file("module_dep_on_test_fixture_case.exs")
+    end
+  end
+
+  test "module fixtures can't depend on test fixtures in fixture module" do
+    assert_raise RuntimeError, ~r/Mis-matched scopes/, fn ->
+      load_file("module_dep_on_test_fixture_module.exs")
+    end
+  end
+
+  defp load_file(filename) do
+    [__DIR__, "compile_failure_files", filename] |> Path.join |> Code.load_file
+  end
+end


### PR DESCRIPTION
The documentation mostly states that the default scope for fixtures is
`:test` scoped, but most of the code that actually sets the value was
setting it to `:function` scope.

This commit fixes that.

This was causing an issue with the dependency validation code that
attempted to stop module scoped fixtures from being able to depend on
test scoped fixtures, as fixtures were never actually test scoped, but
function scoped.

Fixes #28.
