### PR TITLE
Module fixtures now only created once (Fixes #30)

### DIFF
--- a/test/ex_unit_fixtures_test.exs
+++ b/test/ex_unit_fixtures_test.exs
@@ -29,6 +29,7 @@ defmodule ExunitFixturesTest do
   end
 
   deffixture module_fixture(), scope: :module do
+    Agent.update(:module_counter, fn i -> i + 1 end)
     :woo_modules
   end
 
@@ -106,9 +107,15 @@ defmodule ExunitFixturesTest do
     assert context.module_fixture == :woo_modules
   end
 
+
   @tag fixtures: [:test_fixture_with_module_fixture]
   test "test fixtures can depend on module level fixtures", context do
     assert context.test_fixture_with_module_fixture == :woo_modules
+  end
+
+  @tag fixtures: [:test_fixture_with_module_fixture]
+  test "module fixtures are only initialised once", context do
+    assert Agent.get(:module_counter, fn x -> x end) == 1
   end
 
   test "other setup_all functions still run", context do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,2 +1,4 @@
 ExUnit.start()
 ExUnitFixtures.start()
+
+Agent.start_link(fn -> 0 end, name: :module_counter)


### PR DESCRIPTION
Prior to this change, the `create_fixtures` function wasn't making any
decisions about which fixtures it needed to actually create, and was
just assuming that it should create all the fixtures in the dep chain.

This was incorrect - when creating test fixtures, module fixtures should
have already been created, so should not need to be created again.

This fixes that issue, and adds a test to make sure that it doesn't
happen again.
