### PR TITLE
Set @moduledoc false for imp modules. (Fixes #27)

### DIFF
--- a/lib/ex_unit_fixtures/imp.ex
+++ b/lib/ex_unit_fixtures/imp.ex
@@ -1,10 +1,8 @@
 defmodule ExUnitFixtures.Imp do
-  @moduledoc """
-  This module provides most of the implementation details of ExUnitFixtures.
-
-  It is seperated out from the main ExUnitFixtures file so the documentation for
-  users is not mixed in with a bunch of irrelevant details.
-  """
+  @moduledoc false
+  # This module provides most of the implementation details of ExUnitFixtures.
+  # It is seperated out from the main ExUnitFixtures file so the documentation for
+  # users is not mixed in with a bunch of irrelevant details.
 
   alias ExUnitFixtures.FixtureDef
 

--- a/lib/ex_unit_fixtures/imp/file_loader.ex
+++ b/lib/ex_unit_fixtures/imp/file_loader.ex
@@ -1,11 +1,11 @@
 defmodule ExUnitFixtures.Imp.FileLoader do
-  @moduledoc """
-  A GenServer that handles loading fixture files automatically.
+  @moduledoc false
+  # A GenServer that handles loading fixture files automatically.
 
-  It's possible for a user to call `load_fixture_files` manually themselves, but
-  writing this as a GenServer allows us to carry it out as part of the startup
-  of the ExUnitFixtures supervision tree.
-  """
+  # It's possible for a user to call `load_fixture_files` manually themselves, but
+  # writing this as a GenServer allows us to carry it out as part of the startup
+  # of the ExUnitFixtures supervision tree.
+
   use GenServer
 
   @doc """

--- a/lib/ex_unit_fixtures/imp/module_store.ex
+++ b/lib/ex_unit_fixtures/imp/module_store.ex
@@ -1,11 +1,9 @@
 defmodule ExUnitFixtures.Imp.ModuleStore do
-  @moduledoc """
-  This module provides a store for fixture module metadata.
-
-  When a FixtureModule is first defined it should register itself with the
-  module store. This allows other modules to automatically import fixture
-  modules using the metadata in the module store.
-  """
+  @moduledoc false
+  # This module provides a store for fixture module metadata.
+  # When a FixtureModule is first defined it should register itself with the
+  # module store. This allows other modules to automatically import fixture
+  # modules using the metadata in the module store.
 
   @doc false
   def start_link() do

--- a/lib/ex_unit_fixtures/imp/preprocessing.ex
+++ b/lib/ex_unit_fixtures/imp/preprocessing.ex
@@ -1,10 +1,8 @@
 defmodule ExUnitFixtures.Imp.Preprocessing do
-  @moduledoc """
-  Provides functions that pre-process fixtures at compile time.
-
-  Most of the functions provide some sort of transformation or validation
-  process that we need to do on fixtures at compile time.
-  """
+  @moduledoc false
+  # Provides functions that pre-process fixtures at compile time.
+  # Most of the functions provide some sort of transformation or validation
+  # process that we need to do on fixtures at compile time.
 
   alias ExUnitFixtures.FixtureDef
 


### PR DESCRIPTION
This hides the module from the documentation altogether.  I've left most
of the @doc comments in to help developers, and converted the moduledoc
strings into comments.

This should make the documentation a lot more concise - no need for
users to see documentation on the implementation details.
