### PR TITLE
Refactor fixture creation for greater flexibility (Fixes #31)

### DIFF
--- a/lib/ex_unit_fixtures.ex
+++ b/lib/ex_unit_fixtures.ex
@@ -264,12 +264,17 @@ defmodule ExUnitFixtures do
       )
 
       setup_all do
-        {:ok, ExUnitFixtures.Imp.module_scoped_fixtures(@_processed_fixtures)}
+        {:ok, module_store} = ExUnitFixtures.Imp.FixtureStore.start_link
+        {:ok, %{__ex_unit_fixtures: %{module_store: module_store}}}
       end
 
       setup context do
-        {:ok, ExUnitFixtures.Imp.test_scoped_fixtures(context,
-                                                      @_processed_fixtures)}
+        {:ok, ExUnitFixtures.Imp.create_fixtures(
+            context[:fixtures] || [],
+            @_processed_fixtures,
+            %{module: context[:__ex_unit_fixtures][:module_store]},
+            context
+        )}
       end
     end
   end

--- a/lib/ex_unit_fixtures/fixture_module.ex
+++ b/lib/ex_unit_fixtures/fixture_module.ex
@@ -84,7 +84,6 @@ defmodule ExUnitFixtures.FixtureModule do
     quote do
       Module.register_attribute __MODULE__, :fixtures, accumulate: true
       import ExUnitFixtures
-      import ExUnit.Callbacks, only: [on_exit: 2, on_exit: 1]
 
       @before_compile ExUnitFixtures.FixtureModule
 

--- a/lib/ex_unit_fixtures/imp.ex
+++ b/lib/ex_unit_fixtures/imp.ex
@@ -13,11 +13,11 @@ defmodule ExUnitFixtures.Imp do
   @doc """
   Creates fixtures & their deps for a test.
 
-  This will create each fixture in `fixtures` using the `FixtureDef` in
-  fixture_defs. It takes care to create things in the correct order.
+  This will create each fixture in `fixture_names` using the corresponding entry
+  in `fixture_defs`.
 
-  It also loads any existing fixtures from the fixture stores, and stores any
-  newly created fixtures in there also.
+  It will make use of the fixture stores in `store_pids` to fetch & store any
+  module scoped fixtures.
   """
   @spec create_fixtures([:atom], fixture_dict, Map.t, Map.t) :: fixtures
   def create_fixtures(fixture_names, fixture_defs, store_pids, test_context) do

--- a/lib/ex_unit_fixtures/imp/fixture_store.ex
+++ b/lib/ex_unit_fixtures/imp/fixture_store.ex
@@ -1,5 +1,7 @@
 defmodule ExUnitFixtures.Imp.FixtureStore do
-  @moduledoc """
+  @moduledoc false
+
+  @doc """
   Stores fixtures for a session/module.
   """
   def start_link do

--- a/lib/ex_unit_fixtures/imp/fixture_store.ex
+++ b/lib/ex_unit_fixtures/imp/fixture_store.ex
@@ -1,0 +1,24 @@
+defmodule ExUnitFixtures.Imp.FixtureStore do
+  @moduledoc """
+  Stores fixtures for a session/module.
+  """
+  def start_link do
+    Agent.start_link(&Map.new/0)
+  end
+
+  @doc """
+  Gets or creates a fixture by it's `qualified_name`.
+
+  `create_fun` should be a single arg fun that takes the current fixtures dict.
+  """
+  def get_or_create(store, qualified_name, create_fun) do
+    Agent.get_and_update(store, fn fixtures ->
+      if Map.has_key?(fixtures, qualified_name) do
+        {fixtures[qualified_name], fixtures}
+      else
+        fixture = create_fun.(fixtures)
+        {fixture, Map.put(fixtures, qualified_name, fixture)}
+      end
+    end)
+  end
+end

--- a/lib/ex_unit_fixtures/imp/module_store.ex
+++ b/lib/ex_unit_fixtures/imp/module_store.ex
@@ -42,7 +42,8 @@ defmodule ExUnitFixtures.Imp.ModuleStore do
   def find_module(search_module) do
     check_server_running
 
-    Agent.get(__MODULE__, fn state ->
+    __MODULE__
+    |> Agent.get(fn state ->
       for {module, mod_file} <- state, search_module == module, do: mod_file
     end)
     |> List.first

--- a/lib/ex_unit_fixtures/teardown.ex
+++ b/lib/ex_unit_fixtures/teardown.ex
@@ -1,0 +1,66 @@
+defmodule ExUnitFixtures.Teardown do
+  @moduledoc false
+
+  def start_link do
+    Agent.start_link(fn -> %{pids: %{}, teardowns: %{}} end, name: __MODULE__)
+  end
+
+  @doc """
+  Runs teardown for the module registered as `module_ref`.
+  """
+  @spec run(reference) :: :ok
+  def run(module_ref) when is_reference(module_ref) do
+    __MODULE__
+    |> Agent.get_and_update(fn (%{teardowns: tds, pids: pids}) ->
+      {tds[module_ref], %{teardowns: Map.delete(tds, module_ref),
+                          pids: Map.delete(pids, module_ref)}}
+    end)
+    |> Enum.each(&apply &1, [])
+  end
+
+  @doc """
+  Like `register_pid/2` but uses the current process `pid`
+  """
+  @spec register_pid(reference) :: :ok
+  def register_pid(module_ref) when is_reference(module_ref) do
+    register_pid(module_ref, self)
+  end
+
+  @doc """
+  Associates `pid` with `module_ref`
+  """
+  @spec register_pid(reference, pid) :: :ok
+  def register_pid(module_ref, pid)
+  when is_reference(module_ref)
+  and is_pid(pid) do
+    Agent.update(__MODULE__, fn (state = %{pids: pids, teardowns: tds}) ->
+      %{state | pids: Map.put(pids, pid, module_ref),
+        teardowns: Map.put(tds, module_ref, [])}
+    end)
+  end
+
+  @doc """
+  Registers a teardown function for the current test pid.
+
+  For the simple case of test-scoped-fixtures this defers to
+  `ExUnit.Callbacks.on_exit/1`. For module scoped fixtures, this will register
+  the function to run when all the modules tests are done.
+  """
+  @spec register_teardown(:test | :module, fun) :: :ok
+  def register_teardown(scope \\ :test, fun)
+
+  def register_teardown(:test, fun) when is_function(fun, 0) do
+    ExUnit.Callbacks.on_exit(fun)
+  end
+
+  def register_teardown(:module, fun) when is_function(fun, 0) do
+    pid = self
+    Agent.update(__MODULE__, fn (state = %{teardowns: tds, pids: pids}) ->
+      unless Map.has_key?(pids, pid) do
+        raise "register_teardown/2 can only be invoked from the test process"
+      end
+      new_tds = Map.update!(tds, pids[pid], fn list -> [fun|list] end)
+      %{state | teardowns: new_tds}
+    end)
+  end
+end

--- a/test/auto_load_tests/fixtures.exs
+++ b/test/auto_load_tests/fixtures.exs
@@ -3,8 +3,8 @@ defmodule AutoLoadFixtures do
 
   deffixture not_top_level_fixture do
 
-    # Make sure that we _can_ call `on_exit` from a FixtureModule.
-    on_exit fn ->
+    # Make sure that we _can_ call `teardown` from a FixtureModule.
+    teardown :test, fn ->
       1
     end
 

--- a/test/ex_unit_fixtures/imp/fixture_store_test.exs
+++ b/test/ex_unit_fixtures/imp/fixture_store_test.exs
@@ -1,0 +1,37 @@
+defmodule ExUnitFixtures.Imp.FixtureStoreTest do
+  use ExUnit.Case
+
+  alias ExUnitFixtures.Imp.FixtureStore
+
+  setup do
+    {:ok, pid} = FixtureStore.start_link()
+
+    {:ok, %{store: pid}}
+  end
+
+  test "get_or_create only creates once", %{store: store} do
+    entry1 = FixtureStore.get_or_create(store, :test, fn (_) -> make_ref end)
+    entry2 = FixtureStore.get_or_create(store, :test, fn (_) -> make_ref end)
+    assert entry1 == entry2
+  end
+
+  test "get_or_create disambiguates by key", %{store: store} do
+    entry1 = FixtureStore.get_or_create(store, :test, fn (_) -> make_ref end)
+    entry2 = FixtureStore.get_or_create(store, :test2, fn (_) -> make_ref end)
+    assert entry1 != entry2
+  end
+
+  test "create_fun is passed existing fixtures", %{store: store} do
+    entry1 = FixtureStore.get_or_create(store, :test, fn (existing) ->
+      assert Map.keys(existing) == []
+      make_ref
+    end)
+
+    entry2 = FixtureStore.get_or_create(store, :test2, fn (existing) ->
+      assert existing.test == entry1
+      make_ref
+    end)
+
+    assert entry1 != entry2
+  end
+end

--- a/test/ex_unit_fixtures/imp_test.exs
+++ b/test/ex_unit_fixtures/imp_test.exs
@@ -3,19 +3,117 @@ defmodule ExUnitFixturesImpTest do
 
   alias ExUnitFixtures.Imp
   alias ExUnitFixtures.FixtureDef
+  alias ExUnitFixtures.Imp.FixtureStore
 
-  test "test_scoped_fixtures fails when given a missing fixture" do
-    assert_raise RuntimeError, ~r/Could not find a fixture named test/, fn ->
-      Imp.test_scoped_fixtures(%{fixtures: [:test]}, %{})
+  test "create_fixtures fails when given a missing fixture" do
+    assert_raise RuntimeError, ~r/Could not find a fixture named nope/, fn ->
+      Imp.create_fixtures([:nope], %{}, %{}, %{})
     end
   end
 
-  test "test_scoped_fixtures suggests other fixtures when missing" do
+  test "create_fixtures suggests other fixtures when missing" do
     assert_raise RuntimeError, ~r/Did you mean test\?$/, fn ->
       fixture_defs = %{test: %FixtureDef{name: :test},
                         other: %FixtureDef{name: :other}}
 
-      Imp.test_scoped_fixtures(%{fixtures: [:tets]}, fixture_defs)
+      Imp.create_fixtures([:tets], fixture_defs, %{}, %{})
     end
+  end
+
+  @test_fixtures [
+    %FixtureDef{name: :fixture_a,
+                scope: :module,
+                qualified_name: :"SomeModule.fixture_a",
+                qualified_dep_names: [],
+                func: {Kernel, :make_ref}},
+    %FixtureDef{name: :fixture_b,
+                scope: :test,
+                dep_names: [:fixture_a],
+                qualified_name: :"SomeModule.fixture_b",
+                qualified_dep_names: [:"SomeModule.fixture_a"],
+                func: {__MODULE__, :fixture_b_func}},
+    %FixtureDef{name: :not_used,
+                scope: :module,
+                qualified_name: :"SomeModule.not_used",
+                qualified_dep_names: [],
+                func: {__MODULE__, :missing_func}}
+  ]
+
+  def fixture_b_func(fixture_a) do
+    assert fixture_a != nil
+    make_ref
+  end
+
+  test "resolve_fixtures correctly resolves fixtures" do
+    [fixture_a, fixture_b, _] = @test_fixtures
+
+    fixtures = map_fixtures(@test_fixtures)
+
+    resolved = Imp.resolve_fixtures([:fixture_a, :fixture_b], fixtures)
+    assert resolved == [fixture_a, fixture_b]
+  end
+
+  test "create_fixtures creates module and test fixtures" do
+    {:ok, store_pid} = FixtureStore.start_link
+
+    fixtures = map_fixtures(@test_fixtures)
+
+    results = Imp.create_fixtures([:fixture_a, :fixture_b],
+                                  fixtures, %{module: store_pid}, %{})
+
+    assert Map.has_key?(results, :fixture_a)
+    assert Map.has_key?(results, :fixture_b)
+  end
+
+  test "create_fixtures stores module fixtures" do
+    {:ok, store_pid} = FixtureStore.start_link
+
+    fixtures = map_fixtures(@test_fixtures)
+
+    results = Imp.create_fixtures(
+      [:fixture_a], fixtures, %{module: store_pid}, %{}
+    )
+
+    store_fixture = FixtureStore.get_or_create(
+      store_pid, :"SomeModule.fixture_a", fn (_) -> make_ref end
+    )
+
+    assert store_fixture == results.fixture_a
+  end
+
+  test "calling create_fixture twice does not recreate module fixtures" do
+    {:ok, store_pid} = FixtureStore.start_link
+
+    fixtures = map_fixtures(@test_fixtures)
+    results1 = Imp.create_fixtures([:fixture_a, :fixture_b],
+                                   fixtures,
+                                   %{module: store_pid},
+                                   %{})
+    results2 = Imp.create_fixtures([:fixture_a, :fixture_b],
+                                   fixtures,
+                                   %{module: store_pid},
+                                   %{})
+
+    assert results1.fixture_a == results2.fixture_a
+    assert results1.fixture_b != results2.fixture_b
+  end
+
+  test "un-named deps are not returned by create_fixtures" do
+    {:ok, store_pid} = FixtureStore.start_link
+
+    fixtures = map_fixtures(@test_fixtures)
+    results = Imp.create_fixtures(
+      [:fixture_b], fixtures, %{module: store_pid}, %{}
+    )
+
+    refute Map.has_key?(results, :fixture_a)
+    assert Map.has_key?(results, :fixture_b)
+  end
+
+  @spec map_fixtures([FixtureDef.t]) :: Map.t
+  defp map_fixtures(fixtures) do
+    fixtures
+    |> Enum.map(fn fixture -> {fixture.qualified_name, fixture} end)
+    |> Enum.into(%{})
   end
 end

--- a/test/ex_unit_fixtures/teardown_test.exs
+++ b/test/ex_unit_fixtures/teardown_test.exs
@@ -1,0 +1,27 @@
+defmodule ExUnitFixtures.TeardownTest do
+  use ExUnit.Case
+
+  alias ExUnitFixtures.Teardown
+
+  test "module scoped teardown process" do
+    ref = make_ref
+    {:ok, agent} = Agent.start_link(fn -> false end)
+    Teardown.register_pid(ref)
+
+    Teardown.register_teardown(:module, fn ->
+      Agent.update(agent, fn (called_already) ->
+        assert called_already == false
+        true
+      end)
+    end)
+
+    assert Agent.get(agent, fn s -> s end) == false
+
+    Teardown.run(ref)
+
+    assert Agent.get(agent, fn s -> s end) == true
+  end
+
+  # Note: test scoped teardown relies on the ExUnit on_exit function, so is
+  # not tested.
+end

--- a/test/ex_unit_fixtures_test.exs
+++ b/test/ex_unit_fixtures_test.exs
@@ -114,7 +114,7 @@ defmodule ExunitFixturesTest do
   end
 
   @tag fixtures: [:test_fixture_with_module_fixture]
-  test "module fixtures are only initialised once", context do
+  test "module fixtures are only initialised once" do
     assert Agent.get(:module_counter, fn x -> x end) == 1
   end
 

--- a/test/ex_unit_fixtures_test.exs
+++ b/test/ex_unit_fixtures_test.exs
@@ -30,6 +30,11 @@ defmodule ExunitFixturesTest do
 
   deffixture module_fixture(), scope: :module do
     Agent.update(:module_counter, fn i -> i + 1 end)
+
+    teardown :module, fn ->
+      Agent.update(:module_counter, fn _ -> nil end)
+    end
+
     :woo_modules
   end
 
@@ -115,6 +120,11 @@ defmodule ExunitFixturesTest do
 
   @tag fixtures: [:test_fixture_with_module_fixture]
   test "module fixtures are only initialised once" do
+    assert Agent.get(:module_counter, fn x -> x end) == 1
+  end
+
+  @tag fixtures: [:module_fixture]
+  test "module fixtures are not freed till module is finished" do
     assert Agent.get(:module_counter, fn x -> x end) == 1
   end
 

--- a/test/fixture_module_test.exs
+++ b/test/fixture_module_test.exs
@@ -5,7 +5,7 @@ defmodule FirstFixtures do
     :initial
   end
 
-  deffixture overriable2 do
+  deffixture overridable2 do
     :from_first_fixtures
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,5 @@
 ExUnit.start()
+ExUnit.configure(capture_log: true)
 ExUnitFixtures.start()
 
 Agent.start_link(fn -> 0 end, name: :module_counter)


### PR DESCRIPTION
This commit contains a fairly comprehensive refactor of the way fixtures
are created - all fixtures are now created in the tests setup function,
regardless of how they are scoped.

Module scoped fixtures will be stored by a FixtureStore process, which
will be started for each test, and shutdown again afterwards.

This should mean that module scoped fixtures are no longer implicitly
autouse, because they will only be created when they are explicitly
required by a test.  They will still persist throughout the rest of the
run of that file, but don't think there's much I can do about that...
