### PR TITLE
Add `register_fixture` macro.

### DIFF
--- a/lib/ex_unit_fixtures/imp/module_store.ex
+++ b/lib/ex_unit_fixtures/imp/module_store.ex
@@ -6,7 +6,7 @@ defmodule ExUnitFixtures.Imp.ModuleStore do
   # modules using the metadata in the module store.
 
   @doc false
-  def start_link() do
+  def start_link do
     Agent.start_link(fn -> [] end, name: __MODULE__)
   end
 

--- a/test/ex_unit_fixtures_test.exs
+++ b/test/ex_unit_fixtures_test.exs
@@ -69,14 +69,13 @@ defmodule ExunitFixturesTest do
   end
 
   test "deffixture generates a function that can create a fixture" do
-    assert fixture_create_simple == "simple"
+    assert simple == "simple"
   end
 
   test "deffixture adds the fixture to @fixtures" do
     expected = %ExUnitFixtures.FixtureDef{
       name: :simple,
-      func: {ExunitFixturesTest,
-             :fixture_create_simple},
+      func: {ExunitFixturesTest, :simple},
       qualified_name: :"Elixir.ExunitFixturesTest.simple"
     }
     assert expected in @fixtures


### PR DESCRIPTION
This starts the API change work described in #15.  The initial step is
just to provide a `register_fixture` macro that decouples the fixture
function creation from the fixture registration.  This is a small
change, and leaves most of the actual implementation alone.

However this small change enables a few things:
- Pattern matching & guards on arguments for fixtures.  (#9)
- Decoupling the name of the arguments used in the function with the
  actual fixture names.  This is particularly useful when fixtures
  are required for side effects and aren't actually used - you can just
  `_` out the argument and the compiler won't complain. (#24)

At the moment, I've chosen not to remove the `deffixture` macro.  I was
considering it, but for now I'm keeping it around for the convenient
simpler cases.
