### PR TITLE
use require_file instead of load_file to prevent warnings

### DIFF
--- a/lib/ex_unit_fixtures/imp/file_loader.ex
+++ b/lib/ex_unit_fixtures/imp/file_loader.ex
@@ -31,6 +31,6 @@ defmodule ExUnitFixtures.Imp.FileLoader do
       |> Path.wildcard
       |> Enum.sort_by(fn (v) -> v |> Path.split |> Enum.count end)
 
-    modules = Enum.map(paths, &Code.load_file/1)
+    modules = Enum.map(paths, &Code.require_file/1)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -7,9 +7,9 @@ defmodule ExUnitFixtures.Mixfile do
      elixir: "~> 1.1",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps,
-     description: description,
-     package: package,
+     deps: deps(),
+     description: description(),
+     package: package(),
 
      name: "ExUnitFixtures",
      source_url: "https://github.com/obmarg/ex_unit_fixtures",


### PR DESCRIPTION
this allows one to use
```
ExUnitFixtures.load_fixture_files("../**/test/**/fixtures.exs")
```
in `test_helper.exs` and have all fixtures become available accross apps in an umbrella app without the necessity to `Code.require_file` every file and without warnings about reloading modules, see https://github.com/obmarg/ex_unit_fixtures/issues/13